### PR TITLE
pr-review-queue: Count skipped runs as successful

### DIFF
--- a/pr_review_queue.py
+++ b/pr_review_queue.py
@@ -140,8 +140,11 @@ def get_check_runs(github_api, repo, head):
     total_count = check_runs["total_count"]
     successful_runs = 0
 
+    # Both successful and skipped runs count as success
     for run in runs:
-        if run['status'] == "completed" and run['conclusion'] == "success":
+        if (run['status'] == "completed" and
+            (run['conclusion'] == "success" or
+             run['conclusion'] == "skipped")):
             successful_runs += 1
 
     if successful_runs == total_count:


### PR DESCRIPTION
Sometimes CI jobs get skipped (e.g. because they don't apply). If we don't count them as successful, the total count and sum of successful jobs don't match so the overall result is failure. Let's not do that.