### PR TITLE
Add ci ignore list

### DIFF
--- a/ci-ignore-list.yaml
+++ b/ci-ignore-list.yaml
@@ -1,0 +1,1 @@
+image-builder-frontend: 'Red Hat Konflux / image-builder-bonfire-tekton / image-builder-frontend'

--- a/pr_review_queue.py
+++ b/pr_review_queue.py
@@ -183,7 +183,7 @@ def get_ci_ignore_list(repo):
 
 def get_check_runs(github_api, repo, head):
     """
-    Return the combined status of GitHub checks as strong and a state emoji
+    Return the combined status of GitHub checks as string and a state emoji
     """
     check_runs = github_api.checks.list_for_ref(repo=repo, ref=head, per_page=100)
     runs = check_runs["check_runs"]


### PR DESCRIPTION
This can be helpful when we have checks that fail consistently for a while but we're ok leaving them on (to see when they go green again) but still want to keep merging pull requests.

The example I've added here is the `Red Hat Konflux / image-builder-bonfire-tekton / image-builder-frontend` check in the `image-builder-frontend` repository.

You can easily test this locally by running:
`python pr_review_queue.py --org osbuild --repo image-builder-frontend --dry-run`