### PR TITLE
Add the ability to ignore repos and ignore `cloud-image-val`

### DIFF
--- a/.github/workflows/pr-review-queue.yaml
+++ b/.github/workflows/pr-review-queue.yaml
@@ -19,7 +19,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Create PR Review Queue
         run: |
-          python3 pr_review_queue.py --github-token "${{ secrets.GITHUB_TOKEN }}" --queue --org osbuild --slack-format
+          python3 pr_review_queue.py \
+            --github-token "${{ secrets.GITHUB_TOKEN }}" \
+            --queue \
+            --org osbuild \
+            --slack-format \
+            --ignore-repo cloud-image-val
         shell: bash
         env:
           SLACK_NICKS_KEY: "${{ secrets.SLACK_NICKS_KEY }}"

--- a/pr_review_queue.py
+++ b/pr_review_queue.py
@@ -349,7 +349,7 @@ def get_pull_request_properties(github_api, pull_request, org, repo):
     return pr_properties
 
 
-def get_pull_request_list(github_api, org, repo):
+def get_pull_request_list(github_api, org, repo, ignored_repos=None):
     """
     Return a list of pull requests with their properties
     """
@@ -381,6 +381,9 @@ def get_pull_request_list(github_api, org, repo):
                 repo = pull_request.repository_url.split('/')[-1]
                 if archived_repos and repo in archived_repos:
                     print(f" * Repository '{org}/{repo}' is archived or disabled. Skipping.")
+                    continue
+                if ignored_repos and repo in ignored_repos:
+                    print(f" * Repository '{org}/{repo}' is in ignore list. Skipping.")
                     continue
 
             pull_request_props = get_pull_request_properties(github_api, pull_request, org, repo)
@@ -486,6 +489,8 @@ def main():
                         action=argparse.BooleanOptionalAction)
     parser.add_argument("--dry-run", help="Don't send Slack notifications", default=False,
                         action=argparse.BooleanOptionalAction)
+    parser.add_argument("--ignore-repo", help="Repository to ignore (can be specified multiple times)",
+                        action="append", default=[])
     args = parser.parse_args()
 
     # pylint: disable=global-statement
@@ -496,7 +501,7 @@ def main():
 
     init_slack_userlist()
     init_ci_ignore_list()
-    pull_request_list = get_pull_request_list(github_api, args.org, args.repo)
+    pull_request_list = get_pull_request_list(github_api, args.org, args.repo, args.ignore_repo)
 
     if args.queue:
         needs_reviewer, needs_changes, needs_review, needs_conflict_resolution = create_pr_review_queue(


### PR DESCRIPTION
**pr_review_queue: add --ignore-repo**

This allows us to selectively ignore repos that we don't want to get
notified for.

---

**pr-review-queue: ignore cloud-image-val**

We are in this weird situation where we don't own cloud-image-val but
it lives in our org. I would like to lower the amount of review requests
that the bot announces, so let's ignore it. We rarely do reviews there
anyway, so it should be safe.

---